### PR TITLE
Feature/erd and db refinements

### DIFF
--- a/design/database/erd.md
+++ b/design/database/erd.md
@@ -142,13 +142,4 @@ This table contains comments from users. These commenst are either for events (w
 
 
 ## Enums
-Currently, the enums in the model are as follows:
-- UserLevel { 'User', 'Admin' } -> Denotes the privileges of a user in terms of interactions with the system as a whole.
-- TaskPriority { 'Low', 'Medium', 'High' } -> Denotes the priority of a task assigned to event staff.
-- AssociationType { 'Sponsor', 'Organizer', 'Other' } -> Denotes the type of association that a company has with an event.
-- EmploymentType { 'DPP', 'DPC', 'HPP' } -> Denotes the type of employment an employee may have with a company.
-- EmployeeLevel { 'Basic', 'Manager', 'Upper Manager' } -> Denotes whether the employee has managerial responsibilities / privileges within a company, or not. The Upper Manager role represents the overall responsible person (people) that take care of the company in the system.
-- StaffLevel { 'Basic', 'Organizer' } -> Denotes whether the employee has additional (organizer) privileges within a given event.
-- UserStatus { 'available', 'unavailable' } -> Denotes the availability of a user in terms of employment and task opportunities.
-- AssignmentStatus { 'pending', 'accepted', 'rejected' } -> Denotes the status of a staff request to work on a task.
-- AcceptanceStatus { 'pending', 'accepted', 'rejected' } -> Denotes the status of an employee's request to work on an event./
+We use several enum types, their description can be found in the puml file.

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -17,7 +17,7 @@ enum Association {
     Other
 }
 
-enum EmployeeContract {
+enum EmploymentContract {
     DPP
     DPC
     HPP
@@ -210,7 +210,7 @@ entity employment {
     *end_date: date
     ' Allows for descriptions of the employment's purpose.
     description: text
-    *employment_type: <<enum EmployeeContract>>
+    *employment_type: <<enum EmploymentContract>>
     *employee_level: <<enum EmployeeLevel>>
     *created_at: timestamp
     *edited_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -93,8 +93,8 @@ entity work_day {
     *<u>timesheet_id</u>: <<uuid>>
     *<u>work_date</u>: date
     ---
-    *worked_hours: float
-    commentary: text
+    *total_hours: float
+    comment: text
     *is_editable: boolean
     *created_at: timestamp
     *edited_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -267,9 +267,9 @@ event||..o{task
 event|o...o{comment
 task|o...o{comment
 comment}o..||user
-task||..||event_staff : task_creator >
+task||..||event_staff : was\ncreated\nby >
 task||..o{assigned_staff
 assigned_staff}o..||event_staff
-assigned_staff||..||event_staff : decided_by >
+assigned_staff||..||event_staff : is\ndecided\nby >
 user||..o{event_staff
 @enduml

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -17,16 +17,16 @@ enum Association {
     Other
 }
 
+enum EmployeeContract {
+    DPP
+    DPC
+    HPP
+}
+
 enum EmployeeLevel {
     Basic
     Manager
     Upper Manager
-}
-
-enum EmploymentType {
-    DPP
-    DPC
-    HPP
 }
 
 enum StaffLevel {
@@ -208,7 +208,7 @@ entity employment {
         manager_id is therefore the user ID of the manager.
     '/
     *manager_id: <<uuid>> 
-    *employment_type: <<enum EmploymentType>>
+    *employment_type: <<enum EmployeeContract>>
     *hourly_rate: float
     *employee_level: <<enum EmployeeLevel>>
     ' Allows for descriptions of the employment's purpose.

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -203,7 +203,7 @@ entity employment {
     *<u>company_id</u>: <<uuid>>
     ---
     /' 
-        manager_id and company_id give us the manager's employment record.
+        manager_id and company_id give us the manager\'s employment record.
         manager_id is therefore the user ID of the manager.
     '/
     *manager_id: <<uuid>> 
@@ -240,7 +240,7 @@ entity comment {
         Note that the nullability of event_id 
         and task_id is a xor relationship.
         So either event_id is null, and task_id is not null, or the opposite.
-        They can't both be null, or both not be null.
+        They can\'t both be null, or both not be null.
     '/
     event_id: <<uuid>>
     task_id: <<uuid>>

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -163,8 +163,8 @@ together {
         Note: China seems to have a longest format with 18 characters.
         '/
         *VATIN: varchar(18)
-        *phone: string
-        *email: string
+        *phone: varchar(255)
+        *email: varchar(255)
         *avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -297,6 +297,15 @@ entity comment {
 
 /'
   Class relations, possibly with labels.
+
+  Note: One can use `u`, `r`, `d`, `b` values in relation syntax
+        (e.g. `author|o-b-o{books`).
+
+
+        It allows to request some table to be put `up` / `right`
+        / `bottom` / `left` relative to some other table.
+
+        This seems to be undocumented, but it works.
 '/
 user||..|{employment
 timesheet}o..||employment

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -218,7 +218,7 @@ entity employment {
         manager_id and company_id give us the manager\'s employment record.
         manager_id is therefore the user ID of the manager.
     '/
-    *manager_id: <<uuid>> (FK user)
+    manager_id: <<uuid>> (FK user)
     *hourly_wage: float
     *start_date: date
     *end_date: date

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -254,17 +254,17 @@ entity comment {
 '/
 user||..|{employment
 timesheet}o..||employment
-timesheet||..o{work_day
+timesheet||..o{work_day : can\nhave\n >
 timesheet}o..||event
 employment||..o{event_staff
 employment}o..||company
 employment|o..o{employment : manages
 event||.o{associated_company
 company||..o{associated_company
-company||..||address
+company||..||address : has headquaters at >
 company||..o{event_staff
 event||..o{event_staff
-event||..o{task
+event||..o{task : can have associated >
 event|o...o{comment
 task|o...o{comment
 comment}o..||user

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -65,7 +65,7 @@ entity user {
     *user_status <<enum UserStatus>>
     *email: varchar(45)
     *date_of_birth: date
-    *avatar_url: varchar(255)
+    *avatar_path: varchar(255)
     *gender: <<enum Gender>>
     *created_at: timestamp
     *edited_at: timestamp
@@ -111,7 +111,7 @@ together {
         *accepts_staff: boolean
         *work_start: date
         *work_end: date
-        *avatar_url: varchar(255)
+        *avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp
         deleted_at: timestamp
@@ -165,7 +165,7 @@ together {
         *VATIN: varchar(18)
         *contact_phone: string
         *contact_email: string
-        *avatar_url: varchar(255)
+        *avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp
         deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -207,7 +207,7 @@ entity employment {
         manager_id is therefore the user ID of the manager.
     '/
     *manager_id: <<uuid>> 
-    *hourly_rate: float
+    *hourly_wage: float
     *start_date: date
     *end_date: date
     ' Allows for descriptions of the employment's purpose.

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -272,5 +272,4 @@ task||..||event_staff : was\ncreated\nby >
 task||..o{assigned_staff
 assigned_staff}o..||event_staff
 assigned_staff||..||event_staff : is\ndecided\nby >
-user||..o{event_staff
 @enduml

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -95,6 +95,7 @@ entity timesheet {
     *end_date: date
     *total_hours: float
     *is_editable: boolean
+    *status: <<enum ApprovalStatus>>,
     ' allows managers to leave notes in case of errors.
     manager_note: text
     *created_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -80,7 +80,7 @@ entity timesheet {
     *event_id: <<uuid>> (FK event)
     *start_date: date
     *end_date: date
-    *worked_hours: float
+    *total_hours: float
     *is_editable: boolean
     ' allows managers to leave notes in case of errors.
     manager_note: text

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -12,21 +12,21 @@ enum AcceptanceStatus {
 
 enum Association {
     Sponsor
-	Organizer
-	Media
-	Other
+    Organizer
+    Media
+    Other
 }
 
 enum EmployeeLevel {
     Basic
-	Manager
-	Upper Manager
+    Manager
+    Upper Manager
 }
 
 enum EmploymentType {
     DPP
-	DPC
-	HPP
+    DPC
+    HPP
 }
 
 enum StaffLevel {
@@ -36,25 +36,25 @@ enum StaffLevel {
 
 enum TaskPriority {
     Low
-	Medium
-	High
+    Medium
+    High
 }
 
 enum UserLevel {
     User
-	Admin
+    Admin
 }
 
 enum UserSex {
     Female
-	Male
+    Male
     Other
 }
 
 enum UserStatus {
     OK
-	Sick
-	Vacation
+    Sick
+    Vacation
 }
 
 entity user {
@@ -65,9 +65,9 @@ entity user {
     *user_level: <<enum UserLevel>>
     *user_status <<enum UserStatus>>
     *email: varchar(45)
-	*date_of_birth: date
+    *date_of_birth: date
     *avatar_url: varchar(255)
-	*sex: <<enum UserSex>>
+    *sex: <<enum UserSex>>
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -65,8 +65,8 @@ entity user {
     *date_of_birth: date
     *avatar_path: varchar(255)
     *gender: <<enum Gender>>
-    *user_role: <<enum UserRole>>
-    *user_status <<enum UserStatus>>
+    *role: <<enum UserRole>>
+    *status <<enum UserStatus>>
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -109,8 +109,8 @@ together {
         description: text
         website: varchar(255)
         *accepts_staff: boolean
-        *work_start: date
-        *work_end: date
+        *start_date: date
+        *end_date: date
         avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -63,7 +63,7 @@ entity user {
     *name: varchar(255)
     *email: varchar(45)
     *date_of_birth: date
-    *avatar_path: varchar(255)
+    avatar_path: varchar(255)
     *gender: <<enum Gender>>
     *role: <<enum UserRole>>
     *status <<enum UserStatus>>
@@ -111,7 +111,7 @@ together {
         *accepts_staff: boolean
         *work_start: date
         *work_end: date
-        *avatar_path: varchar(255)
+        avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp
         deleted_at: timestamp
@@ -165,7 +165,7 @@ together {
         *VATIN: varchar(18)
         *phone: varchar(255)
         *email: varchar(255)
-        *avatar_path: varchar(255)
+        avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp
         deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -136,7 +136,7 @@ entity task {
 entity assigned_staff {
     *<u>task_id</u>: <<uuid>> (FK task)
     *<u>staff_id</u>: <<uuid>> (FK event_staff)
-    decided_by: <<uuid>>
+    decided_by: <<uuid>> (FK event_staff)
     ---
     *status: <<enum AcceptanceStatus>>
     *created_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -225,9 +225,9 @@ entity event_staff {
     *user_id: <<uuid>> (FK user, part of FK employment)
     *company_id: <<uuid>> (FK company, part of FK employment)
     *event_id: <<uuid>> (FK event)
+    decided_by: <<uuid>> (FK event_staff)
     *role: <<enum EventRole>>
     *acceptance_status: <<enum AcceptanceStatus>>
-    decided_by: <<uuid>> (FK event_staff)
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -251,6 +251,9 @@ entity comment {
     deleted_at: timestamp
 }
 
+/'
+  Class relations, possibly with labels.
+'/
 user||..|{employment
 timesheet}o..||employment
 timesheet||..o{work_day

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -267,9 +267,9 @@ event||..o{task
 event|o...o{comment
 task|o...o{comment
 comment}o..||user
-task||..||event_staff : task_creator
+task||..||event_staff : task_creator >
 task||..o{assigned_staff
 assigned_staff}o..||event_staff
-assigned_staff||..||event_staff : decided_by
+assigned_staff||..||event_staff : decided_by >
 user||..o{event_staff
 @enduml

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -10,6 +10,19 @@ enum AcceptanceStatus {
     Rejected
 }
 
+enum ApprovalStatus {
+    /'
+      A temporary state which preceeds a `Pending` state.
+
+      Suggests an employee currently modifies its workdays
+      and does not want to get his/her timesheet verified yet.
+    '/
+    NotRequested
+    Pending
+    Accepted
+    Rejected
+}
+
 enum Association {
     Sponsor
     Organizer

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -46,7 +46,7 @@ enum TaskPriority {
     High
 }
 
-enum UserLevel {
+enum UserRole {
     User
     Admin
 }
@@ -62,7 +62,7 @@ entity user {
     ---
     ' Full name. They will log in using their email.
     *name: varchar(255) 
-    *user_level: <<enum UserLevel>>
+    *user_role: <<enum UserRole>>
     *user_status <<enum UserStatus>>
     *email: varchar(45)
     *date_of_birth: date

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -124,7 +124,7 @@ entity task {
     *event_id: uuid (FK event)
     *creator_id: uuid (FK event_staff)
     *title: text
-    *description: text
+    description: text
     finished_at: timestamp
     *priority: <<enum TaskPriority>>
     *accepts_staff: boolean

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -136,9 +136,9 @@ entity task {
 entity assigned_staff {
     *<u>task_id</u>: <<uuid>> (FK task)
     *<u>staff_id</u>: <<uuid>> (FK event_staff)
+    decided_by: <<uuid>>
     ---
     *status: <<enum AcceptanceStatus>>
-    decided_by: <<uuid>>
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -4,6 +4,9 @@ skinparam classFontSize 20
 scale 2400 * 2400
 hide circle
 
+/'
+  Denotes the status of an employee\'s request to work on an event.
+'/
 enum AcceptanceStatus {
     Pending
     Accepted
@@ -23,6 +26,9 @@ enum ApprovalStatus {
     Rejected
 }
 
+/'
+  Denotes the type of association that a company has with an event.
+'/
 enum Association {
     Sponsor
     Organizer
@@ -30,40 +36,66 @@ enum Association {
     Other
 }
 
+/'
+  Denotes the type of employment an employee may have with a company.
+'/
 enum EmploymentContract {
     DPP
     DPC
     HPP
 }
 
+/'
+  Denotes whether the employee has managerial responsibilities / privileges
+  within a company, or not. The Upper Manager role represents the overall
+  responsible person (people) that take care of the company in the system.
+'/
 enum EmployeeLevel {
     Basic
     Manager
     CompanyAdministrator
 }
 
+/'
+  Denotes whether the employee has additional (organizer) privileges
+  within a given event.
+'/
 enum EventRole {
     Basic
     Organizer
 }
 
+/'
+  Denotes a gender types that user is allowed to choose from.
+'/
 enum Gender {
     Female
     Male
     Other
 }
 
+/'
+  Denotes the priority of a task assigned to event staff.
+'/
 enum TaskPriority {
     Low
     Medium
     High
 }
 
+/'
+  Denotes the privileges of a user in terms of interactions with the system
+  as a whole.
+'/
 enum UserRole {
     User
     Admin
 }
 
+/'
+  Denotes the availability of a user in terms of employment
+  and task opportunities.
+'/
 enum UserStatus {
     Available
     Unavailable

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -29,15 +29,15 @@ enum EmployeeLevel {
     CompanyAdministrator
 }
 
+enum EventRole {
+    Basic
+    Organizer
+}
+
 enum Gender {
     Female
     Male
     Other
-}
-
-enum StaffLevel {
-    Basic
-    Organizer
 }
 
 enum TaskPriority {
@@ -225,7 +225,7 @@ entity event_staff {
     *user_id: <<uuid>> (FK user, part of FK employment)
     *company_id: <<uuid>> (FK company, part of FK employment)
     *event_id: <<uuid>> (FK event)
-    *staff_level: <<enum StaffLevel>>
+    *role: <<enum EventRole>>
     *acceptance_status: <<enum AcceptanceStatus>>
     decided_by: <<uuid>> (FK event_staff)
     *created_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -189,8 +189,8 @@ together {
 }
 
 entity associated_company {
-    *<u>event_id</u>: <<uuid>>
     *<u>company_id</u>: <<uuid>>
+    *<u>event_id</u>: <<uuid>>
     ---
     *association_type: <<enum Association>>
     *created_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -1,7 +1,7 @@
 @startuml erd
 skinparam Linetype ortho
 skinparam classFontSize 20
-scale 2400 * 2400
+scale 2000 * 2000
 hide circle
 
 /'

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -13,6 +13,7 @@ enum AcceptanceStatus {
 enum Association {
     Sponsor
 	Organizer
+	Media
 	Other
 }
 

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -52,9 +52,8 @@ enum UserRole {
 }
 
 enum UserStatus {
-    OK
-    Sick
-    Vacation
+    Available
+    Unavailable
 }
 
 entity user {

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -125,7 +125,7 @@ entity task {
     *creator_id: uuid (FK event_staff)
     *title: text
     *description: text
-    date_accomplished: timestamp
+    finished_at: timestamp
     *priority: <<enum TaskPriority>>
     *accepts_staff: boolean
     *created_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -107,7 +107,7 @@ together {
         ---
         *name: varchar(255)
         description: text
-        website: url
+        website: varchar(255)
         *accepts_staff: boolean
         *work_start: date
         *work_end: date
@@ -150,7 +150,7 @@ together {
         ---
         *name: varchar(255)
         description: text
-        website: url
+        website: varchar(255)
         /' A Company Registration Number.
 
         Note: Different European countries use different format, some just

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -307,18 +307,18 @@ entity comment {
 '/
 user||..|{employment
 timesheet}o..||employment
-timesheet||..o{work_day : can\nhave\n >
-timesheet}o..||event
+timesheet||.l.o{work_day : can\nhave\n <
+timesheet}o.r.||event
 employment||..o{event_staff
 employment}o..||company
 employment|o..o{employment : manages
 event||.o{associated_company
-company||..o{associated_company
-company||..||address : has headquaters at >
-event||..o{event_staff : is organized by >
-event||..o{task : can have associated >
-event|o...o{comment : can have >
-task|o...o{comment : can have >
+company||.r.o{associated_company
+company||.u.||address : has\nheadquaters\nat <
+event||..o{event_staff : is\norganized\nby >
+event||.r.o{task : can\nhave\nassociated >
+event|o...o{comment : can\nhave >
+task|o...o{comment : can\nhave >
 comment}o..||user : is sent by >
 task||..||event_staff : was\ncreated\nby >
 task||..o{assigned_staff

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -262,7 +262,6 @@ employment|o..o{employment : manages
 event||.o{associated_company
 company||..o{associated_company
 company||..||address : has headquaters at >
-company||..o{event_staff
 event||..o{event_staff : is organized by >
 event||..o{task : can have associated >
 event|o...o{comment : can have >

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -207,13 +207,13 @@ entity employment {
         manager_id is therefore the user ID of the manager.
     '/
     *manager_id: <<uuid>> 
-    *employment_type: <<enum EmployeeContract>>
     *hourly_rate: float
-    *employee_level: <<enum EmployeeLevel>>
-    ' Allows for descriptions of the employment's purpose.
-    description: text
     *start_date: date
     *end_date: date
+    ' Allows for descriptions of the employment's purpose.
+    description: text
+    *employment_type: <<enum EmployeeContract>>
+    *employee_level: <<enum EmployeeLevel>>
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -26,7 +26,7 @@ enum EmployeeContract {
 enum EmployeeLevel {
     Basic
     Manager
-    Upper Manager
+    CompanyAdministrator
 }
 
 enum StaffLevel {

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -101,21 +101,19 @@ entity work_day {
     deleted_at: timestamp
 }
 
-together {
-    entity event {
-        *<u>event_id</u>: <<uuid>>
-        ---
-        *name: varchar(255)
-        description: text
-        website: varchar(255)
-        *accepts_staff: boolean
-        *start_date: date
-        *end_date: date
-        avatar_path: varchar(255)
-        *created_at: timestamp
-        *edited_at: timestamp
-        deleted_at: timestamp
-    }
+entity event {
+    *<u>event_id</u>: <<uuid>>
+    ---
+    *name: varchar(255)
+    description: text
+    website: varchar(255)
+    *accepts_staff: boolean
+    *start_date: date
+    *end_date: date
+    avatar_path: varchar(255)
+    *created_at: timestamp
+    *edited_at: timestamp
+    deleted_at: timestamp
 }
 
 entity task {

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -183,7 +183,7 @@ together {
         region: varchar(255)
         city: varchar(255)
         street: varchar(255)
-        address_number: varchar(255)
+        street_number: varchar(255)
         postal_code: varchar(255)
     }
 }

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -29,6 +29,12 @@ enum EmployeeLevel {
     CompanyAdministrator
 }
 
+enum Gender {
+    Female
+    Male
+    Other
+}
+
 enum StaffLevel {
     Basic
     Organizer
@@ -43,12 +49,6 @@ enum TaskPriority {
 enum UserLevel {
     User
     Admin
-}
-
-enum UserSex {
-    Female
-    Male
-    Other
 }
 
 enum UserStatus {
@@ -67,7 +67,7 @@ entity user {
     *email: varchar(45)
     *date_of_birth: date
     *avatar_url: varchar(255)
-    *sex: <<enum UserSex>>
+    *gender: <<enum Gender>>
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -263,11 +263,11 @@ event||.o{associated_company
 company||..o{associated_company
 company||..||address : has headquaters at >
 company||..o{event_staff
-event||..o{event_staff
+event||..o{event_staff : is organized by >
 event||..o{task : can have associated >
-event|o...o{comment
-task|o...o{comment
-comment}o..||user
+event|o...o{comment : can have >
+task|o...o{comment : can have >
+comment}o..||user : is sent by >
 task||..||event_staff : was\ncreated\nby >
 task||..o{assigned_staff
 assigned_staff}o..||event_staff

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -188,48 +188,46 @@ entity assigned_staff {
     deleted_at: timestamp
 }
 
-together {
-    entity company {
-        *<u>company_id</u>: <<uuid>>
-        ---
-        *name: varchar(255)
-        description: text
-        website: varchar(255)
-        /' A Company Registration Number.
+entity company {
+    *<u>company_id</u>: <<uuid>>
+    ---
+    *name: varchar(255)
+    description: text
+    website: varchar(255)
+    /' A Company Registration Number.
 
-        Note: Different European countries use different format, some just
-                numbers, some letters as well, but they all fit into 16 characters.
-        '/
-        *CRN: varchar(16)
-        /'
-        A Value-Added Tax Identification Number.
-
-        Note: China seems to have a longest format with 18 characters.
-        '/
-        *VATIN: varchar(18)
-        *phone: varchar(255)
-        *email: varchar(255)
-        *avatar_path: varchar(255)
-        *created_at: timestamp
-        *edited_at: timestamp
-        deleted_at: timestamp
-    }
-
-    /' 
-        Normalization for compound type address.
-        In case we want to expand some filtering.
-        Also normalization.
+    Note: Different European countries use different format, some just
+            numbers, some letters as well, but they all fit into 16 characters.
     '/
-    entity address {
-        *<u>company_id<u>: <<uuid>>
-        ---
-        country: varchar(255)
-        region: varchar(255)
-        city: varchar(255)
-        street: varchar(255)
-        street_number: varchar(255)
-        postal_code: varchar(255)
-    }
+    *CRN: varchar(16)
+    /'
+    A Value-Added Tax Identification Number.
+
+    Note: China seems to have a longest format with 18 characters.
+    '/
+    *VATIN: varchar(18)
+    *phone: varchar(255)
+    *email: varchar(255)
+    *avatar_path: varchar(255)
+    *created_at: timestamp
+    *edited_at: timestamp
+    deleted_at: timestamp
+}
+
+/'
+    Normalization for compound type address.
+    In case we want to expand some filtering.
+    Also normalization.
+'/
+entity address {
+    *<u>company_id<u>: <<uuid>>
+    ---
+    country: varchar(255)
+    region: varchar(255)
+    city: varchar(255)
+    street: varchar(255)
+    street_number: varchar(255)
+    postal_code: varchar(255)
 }
 
 entity associated_company {

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -176,7 +176,7 @@ together {
         In case we want to expand some filtering.
         Also normalization.
     '/
-    entity company_address {
+    entity address {
         *<u>company_id<u>: <<uuid>>
         ---
         country: varchar(255)
@@ -260,7 +260,7 @@ employment}o..||company
 employment|o..o{employment : manages
 event||.o{associated_company
 company||..o{associated_company
-company||..||company_address
+company||..||address
 company||..o{event_staff
 event||..o{event_staff
 event||..o{task

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -76,7 +76,7 @@ entity user {
     *name: varchar(255)
     *email: varchar(45)
     *date_of_birth: date
-    avatar_path: varchar(255)
+    *avatar_path: varchar(255)
     *gender: <<enum Gender>>
     *role: <<enum UserRole>>
     *status <<enum UserStatus>>
@@ -124,7 +124,7 @@ entity event {
     *accepts_staff: boolean
     *start_date: date
     *end_date: date
-    avatar_path: varchar(255)
+    *avatar_path: varchar(255)
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp
@@ -177,7 +177,7 @@ together {
         *VATIN: varchar(18)
         *phone: varchar(255)
         *email: varchar(255)
-        avatar_path: varchar(255)
+        *avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp
         deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -218,7 +218,7 @@ entity employment {
         manager_id and company_id give us the manager\'s employment record.
         manager_id is therefore the user ID of the manager.
     '/
-    *manager_id: <<uuid>> 
+    *manager_id: <<uuid>> (FK user)
     *hourly_wage: float
     *start_date: date
     *end_date: date

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -272,4 +272,5 @@ task||..||event_staff : was\ncreated\nby >
 task||..o{assigned_staff
 assigned_staff}o..||event_staff
 assigned_staff||..||event_staff : is\ndecided\nby >
+event_staff}o..||event_staff : appointed\n as an\n organizer
 @enduml

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -60,13 +60,13 @@ entity user {
     *<u>user_id</u>: <<uuid>>
     ---
     ' Full name. They will log in using their email.
-    *name: varchar(255) 
-    *user_role: <<enum UserRole>>
-    *user_status <<enum UserStatus>>
+    *name: varchar(255)
     *email: varchar(45)
     *date_of_birth: date
     *avatar_path: varchar(255)
     *gender: <<enum Gender>>
+    *user_role: <<enum UserRole>>
+    *user_status <<enum UserStatus>>
     *created_at: timestamp
     *edited_at: timestamp
     deleted_at: timestamp

--- a/design/database/erd.puml
+++ b/design/database/erd.puml
@@ -163,8 +163,8 @@ together {
         Note: China seems to have a longest format with 18 characters.
         '/
         *VATIN: varchar(18)
-        *contact_phone: string
-        *contact_email: string
+        *phone: string
+        *email: string
         *avatar_path: varchar(255)
         *created_at: timestamp
         *edited_at: timestamp

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -2,7 +2,7 @@
 
 CREATE TYPE acceptance_status       AS ENUM ('pending', 'accepted', 'rejected');
 CREATE TYPE association             AS ENUM ('sponsor', 'organizer', 'media', 'other');
-CREATE TYPE employee_contract       AS ENUM ('DPP', 'DPC', 'HPP');
+CREATE TYPE employment_contract     AS ENUM ('DPP', 'DPC', 'HPP');
 CREATE TYPE employee_level          AS ENUM ('basic', 'manager', 'company_administrator');
 CREATE TYPE event_role              AS ENUM ('staff', 'organizer');
 CREATE TYPE gender                  AS ENUM ('male', 'female', 'other');
@@ -120,7 +120,7 @@ CREATE TABLE employment
     start_date  DATE NOT NULL,
     end_date    DATE NOT NULL,
     description TEXT,
-    type        employee_contract NOT NULL,
+    type        employment_contract NOT NULL,
     level       employee_level NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -132,6 +132,8 @@ CREATE TABLE employment
     FOREIGN KEY (company_id) REFERENCES company (id),
     FOREIGN KEY (manager_id) REFERENCES user_record  (id),
     -------------------------------------------------------
+    CONSTRAINT check_employment_hourly_wage_gte_0
+        CHECK (hourly_wage >= 0.0),
     CONSTRAINT check_employment_start_date_lte_end_date
         CHECK (start_date >= end_date),
     CONSTRAINT check_employment_created_at_lte_edited_at

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -273,7 +273,7 @@ CREATE TABLE task
     -------------------------------------------------------
     title           VARCHAR(255) NOT NULL,
     description     TEXT,
-    finished_at     DATE,
+    finished_at     TIMESTAMP,
     priority        task_priority NOT NULL,
     accepts_staff   BOOLEAN NOT NULL,
     -------------------------------------------------------

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -32,7 +32,7 @@ CREATE TABLE user_record
     name        VARCHAR(255) NOT NULL,
     email       VARCHAR(255) NOT NULL UNIQUE,
     birth       DATE NOT NULL,
-    avatar_path VARCHAR(255) NOT NULL,
+    avatar_path VARCHAR(255) NOT NULL DEFAULT 'default.jpg',
     gender      gender NOT NULL,
     role        user_role NOT NULL,
     status      user_status NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE company
     vatin       VARCHAR(18) NOT NULL UNIQUE,
     phone       VARCHAR(255) NOT NULL UNIQUE,
     email       VARCHAR(255) NOT NULL UNIQUE,
-    avatar_path VARCHAR(255) NOT NULL,
+    avatar_path VARCHAR(255) NOT NULL DEFAULT 'default.jpg',
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
@@ -155,7 +155,7 @@ CREATE TABLE event
     accepts_staff  BOOLEAN NOT NULL,
     start_date     DATE NOT NULL,
     end_date       DATE NOT NULL,
-    avatar_path    VARCHAR(255) NOT NULL,
+    avatar_path    VARCHAR(255) NOT NULL DEFAULT 'default.jpg',
     -------------------------------------------------------
     created_at     TIMESTAMP NOT NULL DEFAULT now(),
     edited_at      TIMESTAMP NOT NULL DEFAULT now(),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -6,9 +6,9 @@ CREATE TYPE employee_contract       AS ENUM ('DPP', 'DPC', 'HPP');
 CREATE TYPE employee_level          AS ENUM ('basic', 'manager', 'company_administrator');
 CREATE TYPE event_role              AS ENUM ('staff', 'organizer');
 CREATE TYPE gender                  AS ENUM ('male', 'female', 'other');
-CREATE TYPE status                  AS ENUM ('available', 'unavailable');
 CREATE TYPE task_priority           AS ENUM ('low', 'medium', 'high');
 CREATE TYPE user_role               AS ENUM ('user', 'admin');
+CREATE TYPE user_status             AS ENUM ('available', 'unavailable');
 
 
 -- Constraints
@@ -33,7 +33,7 @@ CREATE TABLE user_record
     avatar_url  VARCHAR(255),
     gender      gender NOT NULL,
     role        user_role NOT NULL,
-    status      status NOT NULL,
+    status      user_status NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -1,7 +1,7 @@
 -- Enums
 
 CREATE TYPE acceptance_status       AS ENUM ('pending', 'accepted', 'rejected');
-CREATE TYPE association             AS ENUM ('sponsor', 'organization', 'media', 'other');
+CREATE TYPE association             AS ENUM ('sponsor', 'organizer', 'media', 'other');
 CREATE TYPE employee_contract       AS ENUM ('DPP', 'DPC', 'HPP');
 CREATE TYPE employee_level          AS ENUM ('basic', 'manager', 'company_administrator');
 CREATE TYPE event_role              AS ENUM ('staff', 'organizer');

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -256,8 +256,8 @@ CREATE TABLE event_staff
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
     -------------------------------------------------------
-    FOREIGN KEY (user_id) REFERENCES user_record (id),
-    FOREIGN KEY (company_id) REFERENCES company (id),
+	FOREIGN KEY (user_id, company_id)
+	    REFERENCES employment (user_id, company_id),
     FOREIGN KEY (event_id) REFERENCES event (id),
     FOREIGN KEY (decided_by) REFERENCES event_staff (id),
     -------------------------------------------------------

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -39,6 +39,10 @@ CREATE TABLE user_record
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
     -------------------------------------------------------
+    CONSTRAINT check_user_record_name_len
+        CHECK (char_length(name) >= 1),
+    CONSTRAINT check_user_record_email_len
+        CHECK (char_length(name) >= 3),
     CONSTRAINT check_user_record_created_at_lte_edited_at
         CHECK (edited_at >= created_at)
 );

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -259,7 +259,7 @@ CREATE TABLE event_staff
     FOREIGN KEY (company_id) REFERENCES company (id),
     FOREIGN KEY (decided_by) REFERENCES event_staff (id),
     -------------------------------------------------------
-    CONSTRAINT check_event_stuff_created_at_lte_edited_at
+    CONSTRAINT check_event_staff_created_at_lte_edited_at
         CHECK (edited_at >= created_at)
 );
 

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -32,7 +32,7 @@ CREATE TABLE user_record
     name        VARCHAR(255) NOT NULL,
     email       VARCHAR(255) NOT NULL UNIQUE,
     birth       DATE NOT NULL,
-    avatar_path VARCHAR(255),
+    avatar_path VARCHAR(255) NOT NULL,
     gender      gender NOT NULL,
     role        user_role NOT NULL,
     status      user_status NOT NULL,
@@ -61,7 +61,7 @@ CREATE TABLE company
     vatin       VARCHAR(18) NOT NULL UNIQUE,
     phone       VARCHAR(255) NOT NULL UNIQUE,
     email       VARCHAR(255) NOT NULL UNIQUE,
-    avatar_path VARCHAR(255),
+    avatar_path VARCHAR(255) NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
@@ -155,7 +155,7 @@ CREATE TABLE event
     accepts_staff  BOOLEAN NOT NULL,
     start_date     DATE NOT NULL,
     end_date       DATE NOT NULL,
-    avatar_path    VARCHAR(255),
+    avatar_path    VARCHAR(255) NOT NULL,
     -------------------------------------------------------
     created_at     TIMESTAMP NOT NULL DEFAULT now(),
     edited_at      TIMESTAMP NOT NULL DEFAULT now(),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -284,9 +284,9 @@ CREATE TABLE task
     FOREIGN KEY (event_id) REFERENCES event (id),
     FOREIGN KEY (creator_id) REFERENCES event_staff (id),
     -------------------------------------------------------
-    CONSTRAINT check_event_title_len
+    CONSTRAINT check_task_title_len
         CHECK (char_length(title) >= 1),
-    CONSTRAINT check_event_stuff_created_at_lte_edited_at
+    CONSTRAINT check_task_created_at_lte_edited_at
         CHECK (edited_at >= created_at)
 );
 

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -82,14 +82,14 @@ CREATE TABLE company
 
 CREATE TABLE address
 (
+    company_id  UUID NOT NULL,
+    -------------------------------------------------------
     country       VARCHAR(255) NOT NULL,
     region        VARCHAR(255) NOT NULL,
     city          VARCHAR(255) NOT NULL,
     street        VARCHAR(255) NOT NULL,
     street_number VARCHAR(255) NOT NULL,
     postal_code   VARCHAR(255) NOT NULL,
-    -------------------------------------------------------
-    company_id  UUID NOT NULL,
     -------------------------------------------------------
     PRIMARY KEY (company_id),
     FOREIGN KEY (company_id) REFERENCES company (id),
@@ -111,6 +111,11 @@ CREATE TABLE address
 
 CREATE TABLE employment
 (
+    user_id     UUID NOT NULL,
+    company_id  UUID NOT NULL,
+    -------------------------------------------------------
+    manager_id  UUID,
+    -------------------------------------------------------
     hourly_wage FLOAT NOT NULL,
     start_date  DATE NOT NULL,
     end_date    DATE NOT NULL,
@@ -121,10 +126,6 @@ CREATE TABLE employment
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
-    -------------------------------------------------------
-    user_id     UUID NOT NULL,
-    company_id  UUID NOT NULL,
-    manager_id  UUID,
     -------------------------------------------------------
     PRIMARY KEY (user_id, company_id),
     FOREIGN KEY (user_id) REFERENCES user_record (id),
@@ -167,14 +168,14 @@ CREATE TABLE event
 
 CREATE TABLE associated_company
 (
+    company_id  UUID NOT NULL,
+    event_id    UUID NOT NULL,
+    -------------------------------------------------------
     type        association NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
-    -------------------------------------------------------
-    company_id  UUID NOT NULL,
-    event_id    UUID NOT NULL,
     -------------------------------------------------------
     PRIMARY KEY (company_id, event_id),
     FOREIGN KEY (company_id) REFERENCES company (id),
@@ -189,6 +190,10 @@ CREATE TABLE timesheet
 (
     id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     -------------------------------------------------------
+    user_id      UUID NOT NULL,
+    company_id   UUID NOT NULL,
+    event_id     UUID NOT NULL,
+    --------------------------------------------------------
     start_date   DATE NOT NULL,
     end_date     DATE NOT NULL,
     total_hours  hours_per_month_float NOT NULL DEFAULT 0.0,
@@ -198,10 +203,6 @@ CREATE TABLE timesheet
     created_at   TIMESTAMP NOT NULL DEFAULT now(),
     edited_at    TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at   TIMESTAMP,
-    --------------------------------------------------------
-    user_id      UUID NOT NULL,
-    company_id   UUID NOT NULL,
-    event_id     UUID NOT NULL,
     --------------------------------------------------------
     FOREIGN KEY  (user_id) REFERENCES user_record (id),
     FOREIGN KEY  (company_id) REFERENCES company (id),
@@ -216,7 +217,9 @@ CREATE TABLE timesheet
 
 CREATE TABLE work_day
 (   
+    timesheet_id UUID NOT NULL,
     date         DATE NOT NULL,
+    --------------------------------------------------------
     total_hours  hours_per_day_float NOT NULL DEFAULT 0.0,
     comment      TEXT,
     is_editable  BOOLEAN NOT NULL,
@@ -224,8 +227,6 @@ CREATE TABLE work_day
     created_at   TIMESTAMP NOT NULL DEFAULT now(),
     edited_at    TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at   TIMESTAMP,
-    --------------------------------------------------------
-    timesheet_id UUID NOT NULL,
     --------------------------------------------------------
     PRIMARY KEY  (timesheet_id, date),
     FOREIGN KEY  (timesheet_id) REFERENCES timesheet (id),
@@ -241,16 +242,16 @@ CREATE TABLE event_staff
 (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     -------------------------------------------------------
+    user_id     UUID NOT NULL,
+    company_id  UUID NOT NULL,
+    decided_by  UUID NOT NULL,
+    -------------------------------------------------------
     role        event_role NOT NULL,
     status      acceptance_status NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
-    -------------------------------------------------------
-    user_id     UUID NOT NULL,
-    company_id  UUID NOT NULL,
-    decided_by  UUID NOT NULL,
     -------------------------------------------------------
     FOREIGN KEY (user_id) REFERENCES user_record (id),
     FOREIGN KEY (company_id) REFERENCES company (id),
@@ -265,6 +266,9 @@ CREATE TABLE task
 (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     -------------------------------------------------------
+    event_id    UUID NOT NULL,
+    creator_id  UUID NOT NULL,
+    -------------------------------------------------------
     title           VARCHAR(255) NOT NULL,
     description     TEXT,
     finished_at     DATE,
@@ -274,9 +278,6 @@ CREATE TABLE task
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
-    -------------------------------------------------------
-    event_id    UUID NOT NULL,
-    creator_id  UUID NOT NULL,
     -------------------------------------------------------
     FOREIGN KEY (event_id) REFERENCES event (id),
     FOREIGN KEY (creator_id) REFERENCES event_staff (id),
@@ -290,19 +291,20 @@ CREATE TABLE task
 
 CREATE TABLE assigned_staff
 (
+    task_id     UUID NOT NULL,
+    staff_id    UUID NOT NULL,
+    -------------------------------------------------------
+    decided_by  UUID NOT NULL,
+    -------------------------------------------------------
     status      acceptance_status NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
     -------------------------------------------------------
-    decided_by  UUID NOT NULL,
-    task_id     UUID NOT NULL,
-    staff_id    UUID NOT NULL,
-    -------------------------------------------------------
-    PRIMARY KEY (staff_id, task_id),
-    FOREIGN KEY (decided_by) REFERENCES event_staff (id),
+    PRIMARY KEY (task_id, staff_id),
     FOREIGN KEY (task_id) REFERENCES task (id),
+    FOREIGN KEY (decided_by) REFERENCES event_staff (id),
     FOREIGN KEY (staff_id) REFERENCES event_staff (id),
     -------------------------------------------------------
     CONSTRAINT check_assigned_staff_created_at_lte_edited_at
@@ -314,15 +316,15 @@ CREATE TABLE comment
 (
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     -------------------------------------------------------
+    event_id    UUID,
+    author_id   UUID NOT NULL,
+    task_id     UUID,
+    -------------------------------------------------------
     content     TEXT NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
     deleted_at  TIMESTAMP,
-    -------------------------------------------------------
-    event_id    UUID,
-    author_id   UUID NOT NULL,
-    task_id     UUID,
     -------------------------------------------------------
     FOREIGN KEY (event_id) REFERENCES event (id),
     FOREIGN KEY (author_id) REFERENCES user_record (id),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -70,12 +70,12 @@ CREATE TABLE company
 
 CREATE TABLE address
 (
-    country     VARCHAR(255) NOT NULL,
-    region      VARCHAR(255) NOT NULL,
-    city        VARCHAR(255) NOT NULL,
-    street      VARCHAR(255) NOT NULL,
-    number      VARCHAR(255) NOT NULL,
-    postal_code VARCHAR(255) NOT NULL,
+    country       VARCHAR(255) NOT NULL,
+    region        VARCHAR(255) NOT NULL,
+    city          VARCHAR(255) NOT NULL,
+    street        VARCHAR(255) NOT NULL,
+    street_number VARCHAR(255) NOT NULL,
+    postal_code   VARCHAR(255) NOT NULL,
     -------------------------------------------------------
     company_id  UUID NOT NULL,
     -------------------------------------------------------
@@ -91,7 +91,7 @@ CREATE TABLE address
     CONSTRAINT check_address_street_len
         CHECK (char_length(street) >= 1),
     CONSTRAINT check_address_address_number_len
-        CHECK (char_length(number) >= 1),
+        CHECK (char_length(street_number) >= 1),
     CONSTRAINT check_address_postal_code_len
         CHECK (char_length(postal_code) >= 1)
 );

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -30,7 +30,7 @@ CREATE TABLE user_record
     name        VARCHAR(255) NOT NULL,
     email       VARCHAR(255) NOT NULL UNIQUE,
     birth       DATE NOT NULL,
-    avatar_url  VARCHAR(255),
+    avatar_path VARCHAR(255),
     gender      gender NOT NULL,
     role        user_role NOT NULL,
     status      user_status NOT NULL,
@@ -55,7 +55,7 @@ CREATE TABLE company
     vatin       VARCHAR(18) NOT NULL UNIQUE,
     phone       VARCHAR(255) NOT NULL UNIQUE,
     email       VARCHAR(255) NOT NULL UNIQUE,
-    avatar_url  VARCHAR(255),
+    avatar_path VARCHAR(255),
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),
     edited_at   TIMESTAMP NOT NULL DEFAULT now(),
@@ -138,7 +138,7 @@ CREATE TABLE event
     accepts_staff  BOOLEAN NOT NULL,
     start_date     DATE NOT NULL,
     end_date       DATE NOT NULL,
-    avatar_url     VARCHAR(255),
+    avatar_path    VARCHAR(255),
     -------------------------------------------------------
     created_at     TIMESTAMP NOT NULL DEFAULT now(),
     edited_at      TIMESTAMP NOT NULL DEFAULT now(),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -202,6 +202,7 @@ CREATE TABLE timesheet
     end_date     DATE NOT NULL,
     total_hours  hours_per_month_float NOT NULL DEFAULT 0.0,
     is_editable  BOOLEAN NOT NULL,
+    status       approval_status NOT NULL DEFAULT 'not_requested',
     manager_note TEXT,
     -------------------------------------------------------
     created_at   TIMESTAMP NOT NULL DEFAULT now(),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -319,8 +319,8 @@ CREATE TABLE comment
     id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     -------------------------------------------------------
     event_id    UUID,
-    author_id   UUID NOT NULL,
     task_id     UUID,
+    author_id   UUID NOT NULL,
     -------------------------------------------------------
     content     TEXT NOT NULL,
     -------------------------------------------------------

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -6,9 +6,9 @@ CREATE TYPE employee_contract       AS ENUM ('DPP', 'DPC', 'HPP');
 CREATE TYPE employee_level          AS ENUM ('basic', 'manager', 'company_administrator');
 CREATE TYPE event_role              AS ENUM ('staff', 'organizer');
 CREATE TYPE gender                  AS ENUM ('male', 'female', 'other');
-CREATE TYPE role                    AS ENUM ('user', 'admin');
 CREATE TYPE status                  AS ENUM ('available', 'unavailable');
 CREATE TYPE task_priority           AS ENUM ('low', 'medium', 'high');
+CREATE TYPE user_role               AS ENUM ('user', 'admin');
 
 
 -- Constraints
@@ -32,7 +32,7 @@ CREATE TABLE user_record
     birth       DATE NOT NULL,
     avatar_url  VARCHAR(255),
     gender      gender NOT NULL,
-    role        role NOT NULL,
+    role        user_role NOT NULL,
     status      status NOT NULL,
     -------------------------------------------------------
     created_at  TIMESTAMP NOT NULL DEFAULT now(),

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -1,6 +1,8 @@
 -- Enums
 
 CREATE TYPE acceptance_status       AS ENUM ('pending', 'accepted', 'rejected');
+CREATE TYPE approval_status         AS ENUM ('not_requested', 'pending',
+                                             'accepted', 'rejected');
 CREATE TYPE association             AS ENUM ('sponsor', 'organizer', 'media', 'other');
 CREATE TYPE employment_contract     AS ENUM ('DPP', 'DPC', 'HPP');
 CREATE TYPE employee_level          AS ENUM ('basic', 'manager', 'company_administrator');

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -246,6 +246,7 @@ CREATE TABLE event_staff
     -------------------------------------------------------
     user_id     UUID NOT NULL,
     company_id  UUID NOT NULL,
+    event_id    UUID NOT NULL,
     decided_by  UUID NOT NULL,
     -------------------------------------------------------
     role        event_role NOT NULL,
@@ -257,6 +258,7 @@ CREATE TABLE event_staff
     -------------------------------------------------------
     FOREIGN KEY (user_id) REFERENCES user_record (id),
     FOREIGN KEY (company_id) REFERENCES company (id),
+    FOREIGN KEY (event_id) REFERENCES event (id),
     FOREIGN KEY (decided_by) REFERENCES event_staff (id),
     -------------------------------------------------------
     CONSTRAINT check_event_staff_created_at_lte_edited_at

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -63,6 +63,14 @@ CREATE TABLE company
     -------------------------------------------------------
     CONSTRAINT check_company_name_len
         CHECK (char_length(name) >= 1),
+    CONSTRAINT check_company_crn_len
+        CHECK (char_length(crn) >= 1),
+    CONSTRAINT check_company_vatin_len
+        CHECK (char_length(vatin) >= 1),
+    CONSTRAINT check_company_phone_len
+        CHECK (char_length(phone) >= 2),
+    CONSTRAINT check_company_email_len
+        CHECK (char_length(email) >= 3),
     CONSTRAINT check_company_created_at_lte_edited_at
         CHECK (edited_at >= created_at)
 );

--- a/migrations/20231210123554_init.sql
+++ b/migrations/20231210123554_init.sql
@@ -306,8 +306,8 @@ CREATE TABLE assigned_staff
     -------------------------------------------------------
     PRIMARY KEY (task_id, staff_id),
     FOREIGN KEY (task_id) REFERENCES task (id),
-    FOREIGN KEY (decided_by) REFERENCES event_staff (id),
     FOREIGN KEY (staff_id) REFERENCES event_staff (id),
+    FOREIGN KEY (decided_by) REFERENCES event_staff (id),
     -------------------------------------------------------
     CONSTRAINT check_assigned_staff_created_at_lte_edited_at
         CHECK (edited_at >= created_at)
@@ -329,8 +329,8 @@ CREATE TABLE comment
     deleted_at  TIMESTAMP,
     -------------------------------------------------------
     FOREIGN KEY (event_id) REFERENCES event (id),
-    FOREIGN KEY (author_id) REFERENCES user_record (id),
     FOREIGN KEY (task_id) REFERENCES task (id),
+    FOREIGN KEY (author_id) REFERENCES user_record (id),
     -------------------------------------------------------
     CONSTRAINT check_comment_single_relation_only
         CHECK (


### PR DESCRIPTION
This fixes some bugs in the `init.sql` script and synchronizes the SQL script with ERD.

I tried to keep breaking changes of `init.sql` at minimum, but I had to add
some FKs that were missing and fix some existing FKs there. I had to fix
some enum values (e.g.  s/organization/organizer ) and typos (e.g. `adress` table) as well.

I chose to reorder DB columns so that order in erd.puml and init.sql
is same (it would be crazy to sync it without it).

Now, the ERD can be visualized and used to understand the DB design again.
I repositioned most tables (in ERD) so it looks much better now.

Some `init.sql` identifier changes:

a) s/adress/address
b) s/avatar_url/avatar_path
c) s/employee_contract/employment_contract

We can dump/cherry-pick some commits (e.g. I believe `task.finished_at` column should have TIMESTAMP 
as it was in ERD, not DATE).
But many commits were discussed with @MatV404 .

Thanks.